### PR TITLE
When adding a ppa you must apt update afterwards to install from the ppa

### DIFF
--- a/tasks/ppa.yml
+++ b/tasks/ppa.yml
@@ -8,6 +8,9 @@
     - select
     - seen
 
+- name : (Debian) update apt
+  apt : update_cache=yes
+
 - name : (Debian) install java
   package: name={{item}} state=present
   with_items:


### PR DESCRIPTION
Shouldn't be an issue to use apt vice package because we're already adding a ppa in the task file so we know we're on an apt system.